### PR TITLE
latest xdebug isn't supported on php5. fixed.

### DIFF
--- a/.docker/php-fpm/php-fpm-5.5.dock
+++ b/.docker/php-fpm/php-fpm-5.5.dock
@@ -33,7 +33,7 @@ RUN docker-php-ext-install \
 #    && docker-php-ext-enable memcached
 
 # Install xdebug
-RUN pecl install xdebug \
+RUN pecl install xdebug-2.5.5 \
     && docker-php-ext-enable xdebug
 
 ADD ./bitrix.ini /usr/local/etc/php/conf.d

--- a/.docker/php-fpm/php-fpm-5.6.dock
+++ b/.docker/php-fpm/php-fpm-5.6.dock
@@ -34,7 +34,7 @@ RUN pecl install memcached-2.2.0 \
     && docker-php-ext-enable memcached
 
 # Install xdebug
-RUN pecl install xdebug \
+RUN pecl install xdebug-2.5.5 \
     && docker-php-ext-enable xdebug
 
 ADD ./bitrix.ini /usr/local/etc/php/conf.d

--- a/.docker/workspace/Dockerfile
+++ b/.docker/workspace/Dockerfile
@@ -37,7 +37,7 @@ RUN docker-php-ext-install \
     gd
 
 # Install xdebug
-RUN pecl install xdebug \
+RUN pecl install xdebug-2.5.5 \
     && docker-php-ext-enable xdebug
 
 # Add bin folder of composer to PATH.


### PR DESCRIPTION
to continue installing xdebug with pecl on php5, used this line: pecl install xdebug-2.5.5